### PR TITLE
Replace plaintext sleepy keys with ciphered applet keys in API objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.mobiera.libs</groupId>
    <artifactId>aircast-api</artifactId>
-   <version>2.80</version>
+   <version>2.81</version>
    <name>Aircast API</name>
    <description>Client Library for Mobiera Aircast Containers</description>
    <url>https://github.com/mobiera/aircast-api</url>

--- a/src/main/java/com/mobiera/aircast/api/vo/AppletVO.java
+++ b/src/main/java/com/mobiera/aircast/api/vo/AppletVO.java
@@ -464,17 +464,17 @@ public class AppletVO implements Serializable {
 		})
 	})
 	private Boolean sleepyUpdateConfig;
-	@UI( widgetType = WidgetType.HEX_TEXT, 
-			mode = Mode.READ_WRITE, 
-			label="Sleepy Key", 
-			description="Sleepy Key")
+	@UI( widgetType = WidgetType.HEX_TEXT,
+			mode = Mode.READ_WRITE,
+			label="Applet Key",
+			description="Applet Key")
 	@Section( name = "APPLET_CONFIGURATION")
 	@DisplayWhen({
 		@Conditions({
 			@Condition(field="appletImpl", values = {"SLEEPY"})
 		})
 	})
-	private byte[] sleepyKey;
+	private byte[] appletKey;
 	
 	
 	@UI( widgetType = WidgetType.CHECKBOX, 
@@ -696,11 +696,11 @@ public class AppletVO implements Serializable {
 	public void setSleepyUpdateConfig(Boolean sleepyUpdateConfig) {
 		this.sleepyUpdateConfig = sleepyUpdateConfig;
 	}
-	public byte[] getSleepyKey() {
-		return sleepyKey;
+	public byte[] getAppletKey() {
+		return appletKey;
 	}
-	public void setSleepyKey(byte[] sleepyKey) {
-		this.sleepyKey = sleepyKey;
+	public void setAppletKey(byte[] appletKey) {
+		this.appletKey = appletKey;
 	}
 	public String getTitle() {
 		return title;

--- a/src/main/java/com/mobiera/aircast/api/vo/SimProfileVO.java
+++ b/src/main/java/com/mobiera/aircast/api/vo/SimProfileVO.java
@@ -265,9 +265,9 @@ public class SimProfileVO implements Serializable {
 	})
 	private SleepyCipheringMode sleepyCipheringMode;
 	
-	@UI( widgetType = WidgetType.HEX_TEXT, 
-			mode = Mode.READ_WRITE, 
-			label="Sleepy Default Key", 
+	@UI( widgetType = WidgetType.HEX_TEXT,
+			mode = Mode.READ_WRITE,
+			label="Default Applet Key",
 			description="If Sleepy Applet has been configured with a default static key for this SIM profile, please enter key here")
 	@Section(name = "SLEEPY_CONFIGURATION")
 	@Validator(minSize=16, maxSize=16)
@@ -276,7 +276,7 @@ public class SimProfileVO implements Serializable {
 			@Condition(field="enableSleepyCampaigns", values = {"true"})
 		})
 	})
-	private byte[] sleepyDefaultKey;
+	private byte[] defaultAppletKey;
 	
 	@UI( widgetType = WidgetType.TEXT, 
 			mode = Mode.READ_WRITE, 
@@ -436,11 +436,11 @@ public class SimProfileVO implements Serializable {
 	public void setSecondsBetweenBlocks(Integer secondsBetweenBlocks) {
 		this.secondsBetweenBlocks = secondsBetweenBlocks;
 	}
-	public byte[] getSleepyDefaultKey() {
-		return sleepyDefaultKey;
+	public byte[] getDefaultAppletKey() {
+		return defaultAppletKey;
 	}
-	public void setSleepyDefaultKey(byte[] sleepyDefaultKey) {
-		this.sleepyDefaultKey = sleepyDefaultKey;
+	public void setDefaultAppletKey(byte[] defaultAppletKey) {
+		this.defaultAppletKey = defaultAppletKey;
 	}
 	public Long getDefaultCounter() {
 		return defaultCounter;

--- a/src/main/java/com/mobiera/ms/mno/aircast/api/ms/SimMS.java
+++ b/src/main/java/com/mobiera/ms/mno/aircast/api/ms/SimMS.java
@@ -78,6 +78,7 @@ public class SimMS implements Serializable {
 	private Boolean responseEncryption;
 	private Boolean simOsIccidIncludesLuhnNumber;
 	private byte[] sleepyKey;
+	private byte[] appletKey;
 	private byte[] ekdr;
 	private byte[] sleepyRandom;
 	private Boolean sleepyCipherDiscovery;
@@ -303,6 +304,12 @@ public class SimMS implements Serializable {
 	}
 	public void setSleepyKey(byte[] sleepyKey) {
 		this.sleepyKey = sleepyKey;
+	}
+	public byte[] getAppletKey() {
+		return appletKey;
+	}
+	public void setAppletKey(byte[] appletKey) {
+		this.appletKey = appletKey;
 	}
 	public Boolean getCommandEncryption() {
 		return commandEncryption;


### PR DESCRIPTION
AppletVO.sleepyKey -> appletKey and SimProfileVO.sleepyDefaultKey -> defaultAppletKey (write-only plaintext in, ciphered/masked out). SimMS gains appletKey (ciphered under the sim id) so no plaintext key is ever exchanged in REST payloads. SimMS.sleepyKey is kept for rollout interop.

Bump 2.80 -> 2.81.