### PR TITLE
feat: grant system campaign type decider role to PM administrator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.mobiera.libs</groupId>
    <artifactId>aircast-api</artifactId>
-   <version>2.82</version>
+   <version>2.83</version>
    <name>Aircast API</name>
    <description>Client Library for Mobiera Aircast Containers</description>
    <url>https://github.com/mobiera/aircast-api</url>

--- a/src/main/java/com/mobiera/aircast/api/util/RoleUtil.java
+++ b/src/main/java/com/mobiera/aircast/api/util/RoleUtil.java
@@ -627,6 +627,7 @@ public class RoleUtil  {
 			adminSubRoles.add(APPLET_LIST);
 			adminSubRoles.add(CAMPAIGN_ADMIN);
 			adminSubRoles.add(CAMPAIGN_TYPE_ALL_VIEWER);
+			adminSubRoles.add(CAMPAIGN_TYPE_SYSTEM_DECIDER);
 			adminSubRoles.add(CAMPAIGN_TYPE_API_DECIDER);
 			adminSubRoles.add(CAMPAIGN_TYPE_AD_DECIDER);
 			adminSubRoles.add(CAMPAIGN_TYPE_SLEEPY_FLOW_PREPARER);


### PR DESCRIPTION
## Summary

`10_PM_ADMINISTRATOR` could not see or manage the discovery system campaign: `CampaignService.listCampaignVOs` gates the DISCOVERY campaign type on the explicit `campaign-type-system-*` roles (`IntrospectionService.getCampaignTypesWithRoles`), and the administrator composite only carried `campaign-type-system-viewer` indirectly via `campaign-all-viewer`.

This adds `campaign-type-system-decider` to the `10_PM_ADMINISTRATOR` composite in `RoleUtil`, matching the existing `campaign-type-api-decider` / `campaign-type-ad-decider` grants, so administrators can view, edit, and enable system campaigns (e.g. the boot-created "Sim Profile Discovery System Campaign").

Version bumped to 2.83 (CI publishes on merge to main).

## Deployment note

After pm-model picks up 2.83, set the `BOOLEAN_REGENERATE_KC_ROLES` parameter to `1` so `KeycloakAdminService` rebuilds the role composites in Keycloak, then re-login for the token to include the new role.