### PR TITLE
feat: add appletImpl_7 (DYNAMO) and appletImpl_8 (MICRO) to SimStatVO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.mobiera.libs</groupId>
    <artifactId>aircast-api</artifactId>
-   <version>2.83</version>
+   <version>2.84</version>
    <name>Aircast API</name>
    <description>Client Library for Mobiera Aircast Containers</description>
    <url>https://github.com/mobiera/aircast-api</url>

--- a/src/main/java/com/mobiera/ms/mno/aircast/api/SimStatVO.java
+++ b/src/main/java/com/mobiera/ms/mno/aircast/api/SimStatVO.java
@@ -90,7 +90,9 @@ public class SimStatVO implements Serializable {
 	private Long appletImpl_4 = 0l;
 	private Long appletImpl_5 = 0l;
 	private Long appletImpl_6 = 0l;
-	
+	private Long appletImpl_7 = 0l;
+	private Long appletImpl_8 = 0l;
+
 
 	private Long stk_aliveUsers = 0l;
 	
@@ -307,7 +309,19 @@ public class SimStatVO implements Serializable {
 	public void setAppletImpl_6(Long appletImpl_6) {
 		this.appletImpl_6 = appletImpl_6;
 	}
-	
+	public Long getAppletImpl_7() {
+		return appletImpl_7;
+	}
+	public void setAppletImpl_7(Long appletImpl_7) {
+		this.appletImpl_7 = appletImpl_7;
+	}
+	public Long getAppletImpl_8() {
+		return appletImpl_8;
+	}
+	public void setAppletImpl_8(Long appletImpl_8) {
+		this.appletImpl_8 = appletImpl_8;
+	}
+
 	public Long getP0AvUsers() {
 		return p0AvUsers;
 	}


### PR DESCRIPTION
Adds `appletImpl_7` and `appletImpl_8` fields (with getters/setters) to `SimStatVO` so SIM stats can be persisted per-impl for DYNAMO (index 7) and MICRO (index 8), which previously fell outside the 7 tracked slots. Bumps version to 2.84.

Companion change: mobiera/mno-adapters-sim-ota#40 (maps the new slots in `SimStatService` / `SimStat`).